### PR TITLE
switched the position for two buttons : 'back' and 'start general information'.

### DIFF
--- a/components/transition/section.module.scss
+++ b/components/transition/section.module.scss
@@ -11,15 +11,16 @@
     // justify-self: center;
 
     &__next {
-      grid-column: 1/2;
-      justify-self: end;
-      margin-right: 0rem;
+      grid-column: 2/3;
+      justify-self: start;
+      margin-right: 12rem;
     }
 
     &__back {
-      grid-column: 2/3;
-      justify-self: start;
-      margin-left: 10rem;
+      grid-column: 1/2;
+      grid-row: 1/2;
+      justify-self: end;
+      margin-right: 12rem;
     }
   }
 }

--- a/pages/transition/info.tsx
+++ b/pages/transition/info.tsx
@@ -10,8 +10,8 @@ export default function TransitionInfoPage() {
     <TransitionPage showPanel>
       <TransitionSection
         desc={desc}
-        fwdBtnText={forward}
         to={ROUTES.INFO.GENERAL}
+        fwdBtnText={forward}
       />
     </TransitionPage>
   );

--- a/pages/transition/project.module.scss
+++ b/pages/transition/project.module.scss
@@ -1,4 +1,8 @@
 .desc {
   padding-top: 24rem;
   line-height: 12rem;
+
+  button {
+    // border: 10px red solid;
+  }
 }


### PR DESCRIPTION
changed the grid column for two buttons from section.module.scss

As a strategist, I want to have in my right side the button to start the Program Generation and in my left side the back button, so I can intuitively use those buttons.